### PR TITLE
add texture "144" to textures.cfg, reorder textures by name

### DIFF
--- a/textures.cfg
+++ b/textures.cfg
@@ -1,4 +1,48 @@
 setshader bumpspecmapparallaxworld
+setshaderparam specscale 1 1 1
+setshaderparam parallaxscale 0.01 0.01 0.01
+texture 0 "nobiax/textures/56/diffuse"
+texture n "nobiax/textures/56/normal"
+texture s "nobiax/textures/56/specular"
+texscale 0.5
+
+setshader bumpspecmapparallaxworld
+setshaderparam specscale 1 1 1
+setshaderparam parallaxscale 0.01 0.01 0.01
+texture 0 "nobiax/textures/57/diffuse"
+texture n "nobiax/textures/57/normal"
+texture s "nobiax/textures/57/specular"
+texscale 0.5
+
+setshader bumpspecmapparallaxworld
+texture 0 "nobiax/textures/76/diffus"
+texture z "nobiax/textures/76/height"
+texture n "nobiax/textures/76/normal"
+texture s "nobiax/textures/76/specular"
+texscale 0.5
+
+setshader bumpspecmapparallaxworld
+texture c "nobiax/textures/79/diffuse.png"
+texture n "nobiax/textures/79/normal.png"
+texture s "nobiax/textures/79/specular.png"
+texture z "nobiax/textures/79/height.png"
+texscale 0.25
+
+setshader bumpspecmapparallaxworld
+texture 0 "nobiax/textures/80/diffus"
+texture z "nobiax/textures/80/height"
+texture n "nobiax/textures/80/normal"
+texture s "nobiax/textures/80/specular"
+texscale 0.5
+
+setshader bumpspecmapparallaxworld
+texture 0 "nobiax/textures/91/diffus"
+texture z "nobiax/textures/91/height"
+texture n "nobiax/textures/91/normal"
+texture s "nobiax/textures/91/specular"
+texscale 0.5
+
+setshader bumpspecmapparallaxworld
 setshaderparam "specscale" 0.4 0.4 0.4
 setshaderparam "parallaxscale" 0.01 0
 texture c "nobiax/textures/100/diffuse.png"
@@ -25,6 +69,38 @@ setshaderparam "envscale" .2 .2 .2
 texture c "nobiax/textures/139/diffuse.png"
 texture n "nobiax/textures/139/normal.png"
 texture s "nobiax/textures/139/specular.png"
+texscale 0.5
+
+setshader bumpspecmapparallaxworld
+setshaderparam specscale 1 1 1
+setshaderparam parallaxscale 0.01 0.01 0.01
+texture 0 "nobiax/textures/144/diffuse"
+texture n "nobiax/textures/144/normal"
+texture s "nobiax/textures/144/specular"
+texscale 0.5
+
+setshader bumpspecmapparallaxworld
+setshaderparam specscale 1 1 1
+setshaderparam parallaxscale 0.01 0.01 0.01
+texture 0 "nobiax/textures/145/diffuse"
+texture n "nobiax/textures/145/normal"
+texture s "nobiax/textures/145/specular"
+texscale 0.5
+
+setshader bumpspecmapparallaxworld
+setshaderparam specscale 1 1 1
+setshaderparam parallaxscale 0.01 0.01 0.01
+texture 0 "nobiax/textures/146/diffuse"
+texture n "nobiax/textures/146/normal"
+texture s "nobiax/textures/146/specular"
+texscale 0.5
+
+setshader bumpspecmapparallaxworld
+setshaderparam specscale 1 1 1
+setshaderparam parallaxscale 0.01 0.01 0.01
+texture 0 "nobiax/textures/147/diffuse"
+texture n "nobiax/textures/147/normal"
+texture s "nobiax/textures/147/specular"
 texscale 0.5
 
 setshader bumpspecmapworld
@@ -68,34 +144,6 @@ texture 0 "nobiax/textures/388/diffuse.png"
 texture n "nobiax/textures/388/normal.png"
 texscale 0.5
 
-setshader bumpspecmapparallaxworld
-texture 0 "nobiax/textures/76/diffus"
-texture z "nobiax/textures/76/height"
-texture n "nobiax/textures/76/normal"
-texture s "nobiax/textures/76/specular"
-texscale 0.5
-
-setshader bumpspecmapparallaxworld
-texture c "nobiax/textures/79/diffuse.png"
-texture n "nobiax/textures/79/normal.png"
-texture s "nobiax/textures/79/specular.png"
-texture z "nobiax/textures/79/height.png"
-texscale 0.25
-
-setshader bumpspecmapparallaxworld
-texture 0 "nobiax/textures/80/diffus"
-texture z "nobiax/textures/80/height"
-texture n "nobiax/textures/80/normal"
-texture s "nobiax/textures/80/specular"
-texscale 0.5
-
-setshader bumpspecmapparallaxworld
-texture 0 "nobiax/textures/91/diffus"
-texture z "nobiax/textures/91/height"
-texture n "nobiax/textures/91/normal"
-texture s "nobiax/textures/91/specular"
-texscale 0.5
-
 setshader bumpworld
 texture 0 "nobiax/textures/iron/iron_diffuse"
 texture n "nobiax/textures/iron/iron_normal"
@@ -106,42 +154,3 @@ texture 0 "nobiax/textures/steel/steel_diffuse"
 texture n "nobiax/textures/steel/steel_normal"
 texscale 0.5
 
-setshader bumpspecmapparallaxworld
-setshaderparam specscale 1 1 1
-setshaderparam parallaxscale 0.01 0.01 0.01
-texture 0 "nobiax/textures/56/diffuse"
-texture n "nobiax/textures/56/normal"
-texture s "nobiax/textures/56/specular"
-texscale 0.5
-
-setshader bumpspecmapparallaxworld
-setshaderparam specscale 1 1 1
-setshaderparam parallaxscale 0.01 0.01 0.01
-texture 0 "nobiax/textures/57/diffuse"
-texture n "nobiax/textures/57/normal"
-texture s "nobiax/textures/57/specular"
-texscale 0.5
-
-setshader bumpspecmapparallaxworld
-setshaderparam specscale 1 1 1
-setshaderparam parallaxscale 0.01 0.01 0.01
-texture 0 "nobiax/textures/145/diffuse"
-texture n "nobiax/textures/145/normal"
-texture s "nobiax/textures/145/specular"
-texscale 0.5
-
-setshader bumpspecmapparallaxworld
-setshaderparam specscale 1 1 1
-setshaderparam parallaxscale 0.01 0.01 0.01
-texture 0 "nobiax/textures/146/diffuse"
-texture n "nobiax/textures/146/normal"
-texture s "nobiax/textures/146/specular"
-texscale 0.5
-
-setshader bumpspecmapparallaxworld
-setshaderparam specscale 1 1 1
-setshaderparam parallaxscale 0.01 0.01 0.01
-texture 0 "nobiax/textures/147/diffuse"
-texture n "nobiax/textures/147/normal"
-texture s "nobiax/textures/147/specular"
-texscale 0.5


### PR DESCRIPTION
Fixes #

Changes proposed in this request:

* Reorder textures in cfg as for filepath/name
* Add the below config to texture browser, which was previously missing
```
setshader bumpspecmapparallaxworld
setshaderparam specscale 1 1 1
setshaderparam parallaxscale 0.01 0.01 0.01
texture 0 "nobiax/textures/144/diffuse"
texture n "nobiax/textures/144/normal"
texture s "nobiax/textures/144/specular"
texscale 0.5
```

